### PR TITLE
Add build workflow to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
@@ -17,7 +22,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: multiuserdomain/mud-jena:${GITHUB_REF##*/}
+        tags: multiuserdomain/mud-jena:${{ steps.extract_branch.outputs.branch }}
 
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 on: [push]
 jobs:
-  test:
+  build:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: multiuserdomain/mud-jena:${GITHUB_REF##*/}
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ To run the image, simply bind port 8080 to a local port:
 docker run -p 8080:8080  mud-jena:<branch>
 ```
 
+## CI
+
+We run Docker build on PRs in this repo (restricted to contributors only for security reasons), so if you want to checkout a PR or master, you can use our prebuilt images like so:
+```
+docker run -p 8080:8080 multiuserdomain/mud-jena:master
+
+docker run -p 8080:8080 multiuserdomain/mud-jena:<branch-name>
+```
+
 # Deploying to a production Tomcat server
 
 * In Eclipse, in the Project Explorer, right-click on the MUD project name and select Export / WAR file


### PR DESCRIPTION
# What?

CI to build and push our Docker image to DockerHub when a new push is done

The images will go to a new org I setup: https://hub.docker.com/repository/docker/multiuserdomain/mud-jena

Note: we need to add some secrets to this GitHub repo for this, I don't seem to have access rights - https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository

~@calummackervoy can I be admin pls? Or I can send over details to you and you can add them 😄 ~

I've setup a multiuserdomain org on DockerHub (essentially a group of users, and all our image tags will be prefixed with multiuserdomain). The free plan lets us have 3 members - I've added two (me and a CI user, so random builds aren't attributed to me - it's email goes to me at the moment, but when we get a domain we could look at changing that).

https://hub.docker.com/orgs/multiuserdomain

https://hub.docker.com/repository/docker/multiuserdomain/mud-jena

I'd like to get this merged fairly soon, because then we can Dockerise the other apps and setup a docker-compose file per app that could spin up master branch of all its dependencies, and a local dev environment (so say you wanted to just change mud-react, you could do docker-compose up there and bring up mud-jena master automagically for you, ports bound and everything).

# Why?

Makes it easier to try out other people's work (just pull & run their Docker image). Could also become a PR check, to stop us merging code that doesn't build.

For example, on this branch if you want to run mud-jena locally:
```
docker run -p 8080:8080 multiuserdomain/mud-jena:ci-build-step
```
