### PR TITLE
Action discovery

### DIFF
--- a/src/main/java/com/mackervoy/calum/mud/AbstractMUDController.java
+++ b/src/main/java/com/mackervoy/calum/mud/AbstractMUDController.java
@@ -1,10 +1,16 @@
 package com.mackervoy.calum.mud;
 
 import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
 
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 
 public abstract class AbstractMUDController {
+	
+	public Model serializeTurtleRequestToModel(String requestBody) {
+		return ModelFactory.createDefaultModel().read(new StringReader(requestBody), "", "TURTLE");
+	}
 	
 	public String serializeModelToTurtle(Model m) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
+++ b/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
@@ -3,19 +3,18 @@ package com.mackervoy.calum.mud.behaviour;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.vocabulary.RDF;
 
-import java.io.StringReader;
 import java.util.Set;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 import com.mackervoy.calum.mud.AbstractMUDController;
+import com.mackervoy.calum.mud.MUDApplication;
 import com.mackervoy.calum.mud.behaviour.task.TaskActorFactory;
+import com.mackervoy.calum.mud.vocabularies.MUDLogic;
 
 /**
  * @author Calum Mackervoy
@@ -24,6 +23,11 @@ import com.mackervoy.calum.mud.behaviour.task.TaskActorFactory;
 
 @Path("/mud/act/discover/")
 public class ActionController extends AbstractMUDController {
+	private String getActAtURL(Resource action) {
+		String base = MUDApplication.getSiteUrl() + "mud/act/";
+		return action.getPropertyResourceValue(RDF.type) == MUDLogic.Task ? base + "task/" : base;
+	}
+	
 	// pass a URI in the query string for an object
 	// expect to get back the configured endpoints for actions and tasks on this object
 	@POST
@@ -40,6 +44,7 @@ public class ActionController extends AbstractMUDController {
 			Model m = ModelFactory.createDefaultModel().read(key, "TURTLE");
 			Resource r = m.getResource(key);
 			result.add(r, RDF.type, r.getPropertyResourceValue(RDF.type));
+			result.add(r, MUDLogic.actAt, this.getActAtURL(r));
 		}
 		
 		String responseData = result.isEmpty() ? null : serializeModelToTurtle(result);

--- a/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
+++ b/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
@@ -1,0 +1,49 @@
+package com.mackervoy.calum.mud.behaviour;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.vocabulary.RDF;
+
+import java.io.StringReader;
+import java.util.Set;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import com.mackervoy.calum.mud.AbstractMUDController;
+import com.mackervoy.calum.mud.behaviour.task.TaskActorFactory;
+
+/**
+ * @author Calum Mackervoy
+ * Provides Action Discovery (https://multi-user-domain.github.io/docs/05-action-server.html)
+ */
+
+@Path("/mud/act/discover/")
+public class ActionController extends AbstractMUDController {
+	// pass a URI in the query string for an object
+	// expect to get back the configured endpoints for actions and tasks on this object
+	@POST
+	public Response discoverActions(String requestBody) {
+		// TODO: analyse the objects in the request (the scene), and return those Actions which have matching shapes for them
+		//  https://github.com/Multi-User-Domain/mud-jena/issues/44
+		// final Model request = this.serializeTurtleRequestToModel(requestBody);
+		
+		Model result = ModelFactory.createDefaultModel();
+		
+		Set<String> keys = TaskActorFactory.keySet();
+		
+		for(String key : keys) {
+			Model m = ModelFactory.createDefaultModel().read(key, "TURTLE");
+			Resource r = m.getResource(key);
+			result.add(r, RDF.type, r.getPropertyResourceValue(RDF.type));
+		}
+		
+		String responseData = result.isEmpty() ? null : serializeModelToTurtle(result);
+		return Response.ok(responseData).build();
+  }
+
+}

--- a/src/main/java/com/mackervoy/calum/mud/behaviour/task/TaskActorFactory.java
+++ b/src/main/java/com/mackervoy/calum/mud/behaviour/task/TaskActorFactory.java
@@ -1,9 +1,9 @@
 package com.mackervoy.calum.mud.behaviour.task;
 
 import java.lang.reflect.Constructor;
-import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.ws.rs.BadRequestException;
 
@@ -16,7 +16,7 @@ import com.mackervoy.calum.mud.vocabularies.MUDLogic;
  * Resolves at runtime a TaskActor class for a requested RDF class
  */
 public class TaskActorFactory {
-	private static Dictionary<String, Class<? extends ITaskActor>> taskActors = 
+	private static Hashtable<String, Class<? extends ITaskActor>> taskActors = 
 			new Hashtable<String, Class<? extends ITaskActor>>();
 	
 	/*
@@ -61,5 +61,9 @@ public class TaskActorFactory {
 			e.printStackTrace();
 			return Optional.empty();
 		}
+	}
+	
+	public static Set<String> keySet() {
+		return taskActors.keySet();
 	}
 }

--- a/src/main/java/com/mackervoy/calum/mud/content/ContentController.java
+++ b/src/main/java/com/mackervoy/calum/mud/content/ContentController.java
@@ -28,8 +28,7 @@ public class ContentController extends AbstractMUDController {
 	//NOTE: the ContentContoller POST must receives objects with RDF type set, or it will ignore them
 	@POST
 	public Response post(String requestBody) {
-		final Model request = ModelFactory.createDefaultModel();
-		request.read(new StringReader(requestBody), "", "TURTLE");
+		final Model request = this.serializeTurtleRequestToModel(requestBody);
 	
 		//build the result model by iterating over each object in the scene and annotating a description
 		//TODO: for now we are just describing everything, later we will want to be able to optimise what is described
@@ -37,8 +36,7 @@ public class ContentController extends AbstractMUDController {
 		ResIterator resources = request.listResourcesWithProperty(RDF.type);
 		while(resources.hasNext()) {
 			Resource res = resources.next();
-			Model m = ModelFactory.createDefaultModel();
-			m.read(res.getURI());
+			Model m = ModelFactory.createDefaultModel().read(res.getURI());
 			final Resource r = m.getResource(res.getURI());
 			System.out.println(r);
 			

--- a/src/main/java/com/mackervoy/calum/mud/vocabularies/MUDLogic.java
+++ b/src/main/java/com/mackervoy/calum/mud/vocabularies/MUDLogic.java
@@ -30,6 +30,7 @@ public class MUDLogic {
     public final static Resource Action = resource( "Action" );
     public final static Resource Task = resource( "Task" );
     public final static Resource Transit = resource( "Transit" );
+    public final static Property actAt = property( "actAt" );
     public final static Property taskImplements = property( "taskImplements" );
     public final static Property isComplete = property( "isComplete" );
     public final static Property endState = property( "endState" );

--- a/src/main/webapp/WEB-INF/mudserver.ttl
+++ b/src/main/webapp/WEB-INF/mudserver.ttl
@@ -5,4 +5,5 @@
 :configuration a mud:Configuration ;
     mud:worldEndpoint <http://localhost:8080/mud/world/> ;
     mudcontent:SceneDescriptionEndpoint <http://localhost:8080/mud/content/> ;
-    mudcontent:SimpleObjectDescriptionEndpoint <http://localhost:8080/mud/content/> .
+    mudcontent:SimpleObjectDescriptionEndpoint <http://localhost:8080/mud/content/> ;
+    mudlogic:actionDiscoveryEndpoint <http://localhost:8000/mud/act/discover/> .

--- a/src/main/webapp/WEB-INF/mudserver.ttl
+++ b/src/main/webapp/WEB-INF/mudserver.ttl
@@ -1,3 +1,4 @@
+@prefix : <#>.
 @prefix mud: <https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mud.ttl#>.
 @prefix mudcontent: <https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mudcontent.ttl#>.
 @prefix mudlogic: <https://raw.githubusercontent.com/Multi-User-Domain/vocab/main/mudlogic.ttl#>.
@@ -6,4 +7,5 @@
     mud:worldEndpoint <http://localhost:8080/mud/world/> ;
     mudcontent:SceneDescriptionEndpoint <http://localhost:8080/mud/content/> ;
     mudcontent:SimpleObjectDescriptionEndpoint <http://localhost:8080/mud/content/> ;
-    mudlogic:actionDiscoveryEndpoint <http://localhost:8000/mud/act/discover/> .
+    mudlogic:actionDiscoveryEndpoint <http://localhost:8000/mud/act/discover/> ;
+    mudlogic:Transit <http://localhost:8000/mud/act/task/> .


### PR DESCRIPTION
Closes #33 

# What

Implements an endpoint at `mud/act/discovery/` which returns in `ttl` format a list of endpoints

# Why

Action Discovery allows us to POST a scene and discover the available actions to the user. The client can build on this to construct a game on-the-fly with multiple servers providing Actions

# Linked MRs

* Front-end changes: TODO
* Documentation: https://github.com/Multi-User-Domain/Multi-User-Domain.github.io/pull/5