### PR TITLE
Basic Scene generation: populate with a character

### DIFF
--- a/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
+++ b/src/main/java/com/mackervoy/calum/mud/behaviour/ActionController.java
@@ -4,6 +4,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
 
 import java.util.Set;
 
@@ -43,6 +44,11 @@ public class ActionController extends AbstractMUDController {
 		for(String key : keys) {
 			Model m = ModelFactory.createDefaultModel().read(key, "TURTLE");
 			Resource r = m.getResource(key);
+			String name = r.hasProperty(RDFS.label) ? r.getProperty(RDFS.label, "en").getString() : "";
+			String description = r.hasProperty(RDFS.comment) ? r.getProperty(RDFS.comment, "en").getString() : "";
+			
+			result.add(r, RDFS.label, name);
+			result.add(r, RDFS.comment, description);
 			result.add(r, RDF.type, r.getPropertyResourceValue(RDF.type));
 			result.add(r, MUDLogic.actAt, this.getActAtURL(r));
 		}

--- a/src/main/java/com/mackervoy/calum/mud/content/ContentController.java
+++ b/src/main/java/com/mackervoy/calum/mud/content/ContentController.java
@@ -6,7 +6,6 @@ package com.mackervoy.calum.mud.content;
 import com.mackervoy.calum.mud.AbstractMUDController;
 import com.mackervoy.calum.mud.vocabularies.MUDCharacter;
 
-import java.io.StringReader;
 import java.util.Optional;
 
 import javax.ws.rs.POST;

--- a/src/main/java/com/mackervoy/calum/mud/vocabularies/MUDLogic.java
+++ b/src/main/java/com/mackervoy/calum/mud/vocabularies/MUDLogic.java
@@ -31,6 +31,7 @@ public class MUDLogic {
     public final static Resource Task = resource( "Task" );
     public final static Resource Transit = resource( "Transit" );
     public final static Property actAt = property( "actAt" );
+    public final static Property parameterConstraintsShape = property("parameterConstraintsShape");
     public final static Property taskImplements = property( "taskImplements" );
     public final static Property isComplete = property( "isComplete" );
     public final static Property endState = property( "endState" );

--- a/src/main/java/com/mackervoy/calum/mud/world/SceneController.java
+++ b/src/main/java/com/mackervoy/calum/mud/world/SceneController.java
@@ -6,6 +6,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 
 /**
  * @author Calum Mackervoy
@@ -22,8 +23,8 @@ public class SceneController extends AbstractMUDController {
 		// TODO: context and social context passed in with the scene
 		Model scene = this.serializeTurtleRequestToModel(requestBody);
 		
-		// TODO: for now we just add a hard-coded character to the scene
-		// ...
+		// for now we just add a hard-coded character to the scene
+		scene = scene.union(ModelFactory.createDefaultModel().read("https://calum.inrupt.net/public/collections/scenedemo.ttl", "TURTLE"));
 		
 		return Response.ok(serializeModelToTurtle(scene)).build();
 	}

--- a/src/main/java/com/mackervoy/calum/mud/world/SceneController.java
+++ b/src/main/java/com/mackervoy/calum/mud/world/SceneController.java
@@ -1,0 +1,30 @@
+package com.mackervoy.calum.mud.world;
+
+import com.mackervoy.calum.mud.AbstractMUDController;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.apache.jena.rdf.model.Model;
+
+/**
+ * @author Calum Mackervoy
+ * Provides endpoints to help generate objects into a scene 
+ * (e.g. a character walks into a bar and expects to see occupants)
+ */
+@Path("/mud/scene/")
+public class SceneController extends AbstractMUDController {
+	//NOTE: the ContentContoller POST must receives objects with RDF type set, or it will ignore them
+	@POST
+	public Response post(String requestBody) {
+		// the request object will contain the scene as passed by the client
+		// e.g. the clientside characters and the selected building
+		// TODO: context and social context passed in with the scene
+		Model scene = this.serializeTurtleRequestToModel(requestBody);
+		
+		// TODO: for now we just add a hard-coded character to the scene
+		// ...
+		
+		return Response.ok(serializeModelToTurtle(scene)).build();
+	}
+}

--- a/src/main/webapp/WEB-INF/mudserver.ttl
+++ b/src/main/webapp/WEB-INF/mudserver.ttl
@@ -5,6 +5,7 @@
 
 :configuration a mud:Configuration ;
     mud:worldEndpoint <http://localhost:8080/mud/world/> ;
+    mud:sceneGenerationEndpoint <http://localhost:8080/mud/scene/> ;
     mudcontent:SceneDescriptionEndpoint <http://localhost:8080/mud/content/> ;
     mudcontent:SimpleObjectDescriptionEndpoint <http://localhost:8080/mud/content/> ;
     mudlogic:actionDiscoveryEndpoint <http://localhost:8000/mud/act/discover/> ;

--- a/src/main/webapp/WEB-INF/mudserver.ttl
+++ b/src/main/webapp/WEB-INF/mudserver.ttl
@@ -8,5 +8,5 @@
     mud:sceneGenerationEndpoint <http://localhost:8080/mud/scene/> ;
     mudcontent:SceneDescriptionEndpoint <http://localhost:8080/mud/content/> ;
     mudcontent:SimpleObjectDescriptionEndpoint <http://localhost:8080/mud/content/> ;
-    mudlogic:actionDiscoveryEndpoint <http://localhost:8000/mud/act/discover/> ;
-    mudlogic:Transit <http://localhost:8000/mud/act/task/> .
+    mudlogic:actionDiscoveryEndpoint <http://localhost:8080/mud/act/discover/> ;
+    mudlogic:Transit <http://localhost:8080/mud/act/task/> .

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -26,7 +26,7 @@
   <context-param>
     <param-name>com.mackervoy.calum.mud.BASE_URL</param-name>
     <param-value>http://localhost:8080/</param-value>
-    <description>The base URL which the site is deployed to e.g.</description>
+    <description>The base URL which the site is deployed to</description>
   </context-param>
   
   <context-param>


### PR DESCRIPTION
Closes #36 

# What

* Adds `mud:sceneGenerationEndpoint` to the MUD configuration
* The client is expected to POST a scene to start with (e.g. the building I selected and my party characters)
* The server will then add a hard-coded character to the scene and return this
* It is then the client's responsibility to render content for the scene to the user

# Why

* It allows a mechanism for server-side content to be generated when building a scene (later it will be extended to accept context-type parameters)
* Building the scene is a starting point to build a specific kind of scene - a dialogue (#40 )